### PR TITLE
Use special prefix chars for entry

### DIFF
--- a/hyp3_rtc_gamma/__main__.py
+++ b/hyp3_rtc_gamma/__main__.py
@@ -44,9 +44,9 @@ EARTHDATA_LOGIN_DOMAIN = 'urs.earthdata.nasa.gov'
 
 
 def entry():
-    parser = ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
+    parser = ArgumentParser(prefix_chars='+', formatter_class=ArgumentDefaultsHelpFormatter)
     parser.add_argument(
-        '--entrypoint', choices=['hyp3_rtc_gamma', 'hyp3_rtc_gamma_v2'], default='hyp3_rtc_gamma',
+        '++entrypoint', choices=['hyp3_rtc_gamma', 'hyp3_rtc_gamma_v2'], default='hyp3_rtc_gamma',
         help='Select the HyP3 entrypoint version to use'
     )
     args, unknowns = parser.parse_known_args()


### PR DESCRIPTION
This allow `--help` to fall though to the processing entrypoint and `++help` will provide the `entry` fn help