### PR TITLE
get output directory from rtc_sentinel

### DIFF
--- a/hyp3_rtc_gamma/__main__.py
+++ b/hyp3_rtc_gamma/__main__.py
@@ -128,7 +128,7 @@ def main_v2():
     logging.basicConfig(filename=log_file, format=log_format, datefmt='%m/%d/%Y %I:%M:%S %p', level=logging.INFO)
     logging.getLogger().addHandler(logging.StreamHandler())
 
-    hyp3_rtc_gamma.rtc_sentinel.rtc_sentinel_gamma(
+    output_folder = hyp3_rtc_gamma.rtc_sentinel.rtc_sentinel_gamma(
         in_file=granule_zip_file,
         match_flag=False,
         dead_flag=True,
@@ -148,8 +148,6 @@ def main_v2():
     # decide final product name? (move to rtc sentinel?)
 
     # zip output folder? (skip for now?)
-
-    output_folder = args.granule + '-30m-power-rtc-gamma'
 
     if args.bucket:
         upload_folder_to_s3(output_folder, args.bucket, args.bucket_prefix)

--- a/hyp3_rtc_gamma/rtc_sentinel.py
+++ b/hyp3_rtc_gamma/rtc_sentinel.py
@@ -740,6 +740,7 @@ def rtc_sentinel_gamma(in_file,
     create_consolidated_log(aux_name, out_name, lo_flag, dead_flag, match_flag, gamma_flag, roi,
                             shape, pwr_flag, filter_flag, pol, looks, log_file, smooth, terms,
                             no_cross_pol, par)
+    return out_name
 
 
 def main():


### PR DESCRIPTION
Previous method of builing the output from literals and granule name is brittle, instead this allows rtc_sentinel to tell the entrypoint where it put files