### PR TITLE
Move ESA citation file generation into science code

### DIFF
--- a/hyp3_rtc_gamma/__main__.py
+++ b/hyp3_rtc_gamma/__main__.py
@@ -30,7 +30,7 @@ from hyp3proclib import (
     zip_dir,
 )
 from hyp3proclib.db import get_db_connection
-from hyp3proclib.file_system import add_citation, cleanup_workdir
+from hyp3proclib.file_system import cleanup_workdir
 from hyp3proclib.logger import log
 from hyp3proclib.proc_base import Processor
 from pkg_resources import load_entry_point
@@ -373,7 +373,6 @@ def process_rtc_gamma(cfg, n):
                 add_browse(cfg, 'LOW-RES', browse_path)
 
                 find_browses(cfg, out_path)
-                add_citation(cfg, out_path)
                 zip_dir(out_path, zip_file)
 
                 cfg['final_product_size'] = [os.stat(zip_file).st_size, ]

--- a/hyp3_rtc_gamma/rtc_sentinel.py
+++ b/hyp3_rtc_gamma/rtc_sentinel.py
@@ -23,6 +23,7 @@ from hyp3lib.get_dem import get_dem
 from hyp3lib.ingest_S1_granule import ingest_S1_granule
 from hyp3lib.makeAsfBrowse import makeAsfBrowse
 from hyp3lib.make_cogs import cogify_dir
+from hyp3lib.metadata import add_esa_citation
 from hyp3lib.ps2dem import ps2dem
 from hyp3lib.raster_boundary2shape import raster_boundary2shape
 from hyp3lib.rtc2color import rtc2color
@@ -737,6 +738,7 @@ def rtc_sentinel_gamma(in_file,
     create_arc_xml(in_file, aux_name, input_type, gamma_flag, pwr_flag, filter_flag, looks, pol, cpol,
                    dem_type, res, hyp3_rtc_gamma.__version__, gamma_ver, rtc_name)
     cogify_dir(res=res)
+    add_esa_citation(in_file, 'PRODUCT')
     clean_prod_dir()
     perform_sanity_checks()
     logging.info("===================================================================")


### PR DESCRIPTION
For HyP3 v2, we want the science code to handle generating a final, unzipped, product entirely. 

This moves adding the ESA citation file from the `v1` entrypoint (after the science code has ran) to inside the science code. 

Because `hyp3proclib` is depreciated, and an updated version of `add_esa_citation` is available in `hyp3lib`, let's use that. 

`add_esa_citation` will throw a `hyp3lib.GranuleError` if the input granule isn't a S1 granule (`hyp3proclib.add_citation` would fail silently). We shouldn't need to worry about this because `rtc_sentinel.py` is only called for S1 granules (`legacy_rtc.py` is called for `E1`, `E2`, `R1`, and `J1` granules, or an unrecognized granule exception is thrown for none of the aforementioned types). 