### PR TITLE
drop -j flag from calls to mk_geo_radcal

### DIFF
--- a/hyp3_rtc_gamma/rtc_sentinel.py
+++ b/hyp3_rtc_gamma/rtc_sentinel.py
@@ -140,7 +140,7 @@ def process_pol(in_file, rtc_name, aux_name, pol, res, look_fact, match_flag, de
         execute(f"enh_lee {mgrd} temp.mgrd {width} {el_looks} 1 7 7", uselogging=True)
         shutil.move("temp.mgrd", mgrd)
 
-    options = "-p -j -n {} -q -c ".format(terms)
+    options = "-p -n {} -q -c ".format(terms)
     if gamma_flag:
         options += "-g "
 
@@ -269,7 +269,7 @@ def process_2nd_pol(in_file, rtc_name, cpol, res, look_fact, gamma_flag, filter_
         execute(f"enh_lee {mgrd} temp.mgrd {width} {el_looks} 1 7 7", uselogging=True)
         shutil.move("temp.mgrd", mgrd)
 
-    options = "-p -j -n {} -q -c ".format(terms)
+    options = "-p -n {} -q -c ".format(terms)
     if gamma_flag:
         options += "-g "
 


### PR DESCRIPTION
from mk_geo_radcal's usage docs:
`-j           (option) do not use layover-shadow map in the calculation of pixel_area`

Verified the -j flag is now absent for both the co-pol and cross-pol calls.  Didn't test the matching case, but I'm comfortable merging.
```
Running command: mk_geo_radcal S1A_IW_RT30_20170708T161200_G_gpn.VV.mgrd S1A_IW_RT30_20170708T161200_G_gpn.VV.mgrd.par area.dem area.dem.par geo_VV/area.dem geo_VV/area.dem_par geo_VV image 30 0 -p -n 1 -q -c -g 
Running command: mk_geo_radcal S1A_IW_RT30_20170708T161200_G_gpn.VV.mgrd S1A_IW_RT30_20170708T161200_G_gpn.VV.mgrd.par area.dem area.dem.par geo_VV/area.dem geo_VV/area.dem_par geo_VV image 30 3 -p -n 1 -q -c -g 
Running command: mk_geo_radcal S1A_IW_RT30_20170708T161200_G_gpn.VH.mgrd S1A_IW_RT30_20170708T161200_G_gpn.VH.mgrd.par area.dem area.dem.par geo_VV/area.dem geo_VV/area.dem_par geo_VH image 30 3 -p -n 1 -q -c -g 
```