### PR TITLE
Pull in hyp3 libs bugfixes

### DIFF
--- a/conda-env.yml
+++ b/conda-env.yml
@@ -36,5 +36,5 @@ dependencies:
     # For running
     - --trusted-host hyp3-pypi.s3-website-us-east-1.amazonaws.com
       --extra-index-url http://hyp3-pypi.s3-website-us-east-1.amazonaws.com
-    - hyp3lib>=1.2.1,<2
-    - hyp3proclib~=1.0
+    - hyp3lib>=1.2.3,<2
+    - hyp3proclib>=1.0.1,<2

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,8 @@ setup(
 
     install_requires=[
         'boto3',
-        'hyp3lib>=1.2.1,<2',
-        'hyp3proclib~=1.0',
+        'hyp3lib>=1.2.3,<2',
+        'hyp3proclib>=1.0.1,<2',
         'importlib_metadata',
         'lxml',
         'numpy',


### PR DESCRIPTION
This pulls in the latest `hpy3lib` and `hpy3proclib`, which includes a `nodata` bugfix for DEMs and a `default_rtc_resolution` bugfix, respectively.

---

Needs asfadmin/hyp3-lib#175 and asfadmin/hyp3-proc-lib#4